### PR TITLE
feat: add oakCors middleware

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,6 +3,7 @@
         "dev": "deno run --allow-net --allow-read --watch src/main.ts"
     },
     "imports": {
-        "oak": "https://deno.land/x/oak/mod.ts"
+        "oak": "https://deno.land/x/oak/mod.ts",
+        "cors": "https://deno.land/x/cors/mod.ts"
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 // src/main.ts
 
 import { Application, Router } from "oak";
+import { oakCors } from "cors"
 
 import { loadCache } from './data/cache.ts';
 
@@ -17,6 +18,8 @@ router.get('/country/:ccid', countryData);
 
 server.use(router.routes());
 server.use(router.allowedMethods())
+
+server.use(oakCors()) // any origin
 
 console.info("Server initialised. Listening on http://127.0.0.1:8080.");
 


### PR DESCRIPTION
#7 - Bug Fix
Added the `cors` module, which provides middleware for Oak (`oakCors`).
At this time all origins are supported, this behaviour can be adjusted in the future.