### PR TITLE
fix: remove flag-api property

### DIFF
--- a/src/services/getCountryDetails.ts
+++ b/src/services/getCountryDetails.ts
@@ -9,7 +9,6 @@ function _parseResponse(feature: any, cacheStatus: boolean) {
 			href: `/country/${feature.properties.ISO_A3}`,
 			name: feature.properties.ADMIN,
 			code: feature.properties.ISO_A3,
-			flag: `https://countryflagsapi.com/svg/${feature.properties.ISO_A3}`,
 			cached: cacheStatus
 		},
 		geometry: {


### PR DESCRIPTION
See: #16 
The URL for the flag (via: `countryflagsapi.com`) of each country has been removed.